### PR TITLE
Bypass ResizeObserver for print section to fix mobile rendering

### DIFF
--- a/client/src/components/music/VexFlowRenderer.jsx
+++ b/client/src/components/music/VexFlowRenderer.jsx
@@ -2,16 +2,20 @@ import { useEffect, useRef, useState } from "react";
 import { Renderer } from "vexflow";
 import { renderScale } from "../../../lib/render/vexflowRenderer";
 
-export default function VexFlowRenderer({ scaleData, options }) {
+export default function VexFlowRenderer({ scaleData, options, forcedWidth }) {
   const containerRef = useRef(null);
 
   const { directionMode } = options;
   //console.log(`Asc and/or desc: ${directionMode}`);
 
-  const [containerWidth, setContainerWidth] = useState(0);
+  // When forcedWidth is provided (e.g. the print section) we skip ResizeObserver
+  // entirely and start with the correct width immediately, avoiding the async
+  // layout-then-observe cycle that can miss the window.print() deadline on mobile.
+  const [containerWidth, setContainerWidth] = useState(forcedWidth ?? 0);
 
-  // Updating the window width as the size changes
+  // Updating the window width as the size changes (skipped when width is forced)
   useEffect(() => {
+    if (forcedWidth !== undefined) return;
     if (!containerRef.current) return;
 
     const updateContainerWidth = () => {
@@ -37,7 +41,7 @@ export default function VexFlowRenderer({ scaleData, options }) {
       resizeObserver.disconnect();
       window.removeEventListener("resize", updateContainerWidth);
     };
-  }, []);
+  }, [forcedWidth]);
 
   // checking initializations
   useEffect(() => {

--- a/client/src/components/music/VexFlowSheet.jsx
+++ b/client/src/components/music/VexFlowSheet.jsx
@@ -286,7 +286,11 @@ export default function VexFlowSheet({
           {fetchError ? (
             <p className="sheet-error">{fetchError}</p>
           ) : (
-            <VexFlowRenderer scaleData={scaleData} options={options} />
+            <VexFlowRenderer
+              scaleData={scaleData}
+              options={options}
+              forcedWidth={isPrintMode ? 1024 : undefined}
+            />
           )}
         </div>
       </div>


### PR DESCRIPTION
Even with the response cache, VexFlowRenderer still started with containerWidth=0 and needed ResizeObserver to fire before it could draw. On mobile (forwarded port), the async layout+observe cycle can take longer than the 500ms print delay, leaving the SVG undrawn.

Add a forcedWidth prop to VexFlowRenderer. When provided it is used as the initial containerWidth and the ResizeObserver effect is skipped entirely. VexFlowSheet passes forcedWidth={1024} when renderMode is "print", so the print section renderer starts with the correct width from its very first render cycle. Combined with the response cache, scaleData and containerWidth are both available immediately after mount and VexFlow draws the SVG well within the print delay on any device.