### PR TITLE
Fix mobile print by rendering in-place instead of an overflow section

### DIFF
--- a/client/src/components/music/VexFlowRenderer.jsx
+++ b/client/src/components/music/VexFlowRenderer.jsx
@@ -8,10 +8,18 @@ export default function VexFlowRenderer({ scaleData, options, forcedWidth }) {
   const { directionMode } = options;
   //console.log(`Asc and/or desc: ${directionMode}`);
 
-  // When forcedWidth is provided (e.g. the print section) we skip ResizeObserver
-  // entirely and start with the correct width immediately, avoiding the async
+  // When forcedWidth is provided (e.g. during printing) we skip ResizeObserver
+  // entirely and use the target width immediately, avoiding the async
   // layout-then-observe cycle that can miss the window.print() deadline on mobile.
   const [containerWidth, setContainerWidth] = useState(forcedWidth ?? 0);
+
+  // Sync containerWidth whenever forcedWidth is set or cleared.
+  // useState only uses the initializer once, so prop changes need an effect.
+  useEffect(() => {
+    if (forcedWidth !== undefined) {
+      setContainerWidth(forcedWidth);
+    }
+  }, [forcedWidth]);
 
   // Updating the window width as the size changes (skipped when width is forced)
   useEffect(() => {

--- a/client/src/pages/Worksheet.jsx
+++ b/client/src/pages/Worksheet.jsx
@@ -37,10 +37,22 @@ export default function Worksheet() {
   const [printMode, setPrintMode] = useState(false);
 
   function handleClick() {
+    const viewportMeta = document.querySelector('meta[name="viewport"]');
+    const originalViewport = viewportMeta.getAttribute("content");
+
+    // Switch existing renderers to 1024px via renderMode="print" / forcedWidth.
+    // This modifies the VISIBLE content so mobile browsers capture it correctly —
+    // a separate off-screen section sits in overflow and is missed by mobile
+    // Chrome's print engine.
     setPrintMode(true);
-    // Wait for React to commit the print section and VexFlow to render at 1024px
+
     setTimeout(() => {
+      // Set viewport to 1024px so mobile browsers lay out at the print width
+      // before the print dialog captures the page.
+      viewportMeta.setAttribute("content", "width=1024");
       window.print();
+      // Restore viewport and re-attach ResizeObserver for normal interaction.
+      viewportMeta.setAttribute("content", originalViewport);
       setPrintMode(false);
     }, 500);
   }
@@ -77,12 +89,11 @@ export default function Worksheet() {
   return (
     <div className="body-wrapper">
       <h1 className="page-title">Scale-able Worksheet</h1>
-      <section className="worksheet-page no-print">
-        <div className="worksheet-editor">
+      <section className="worksheet-page">
+        <div className="worksheet-editor no-print">
           <div className="worksheet-button-container">
             <button onClick={addScaleRow}>
-              Add Scale ({worksheetScales.length}
-              {/*`Scale${worksheetScales.length > 1 ? "s" : ""}`*/})
+              Add Scale ({worksheetScales.length})
             </button>
             <button type="button" onClick={() => handleClick()}>
               Print Worksheet
@@ -104,9 +115,10 @@ export default function Worksheet() {
                 endpoint="/api/scale"
                 variant="original"
                 scaleTitle={`Scale ${scaleRow.id}`}
+                renderMode={printMode ? "print" : undefined}
               />
             </ErrorBoundary>
-            <div className="remove-button-container">
+            <div className="remove-button-container no-print">
               <button onClick={() => removeScaleRow(scaleRow.id)}>
                 Remove
               </button>
@@ -114,30 +126,6 @@ export default function Worksheet() {
           </div>
         ))}
       </section>
-      {printMode && (
-        <section className="worksheet-page" style={{ width: "1024px" }}>
-          {worksheetScales.map((scaleRow) => (
-            <div key={scaleRow.id}>
-              <ErrorBoundary
-                fallback={
-                  <p className="sheet-error">
-                    Scale {scaleRow.id} could not be displayed.
-                  </p>
-                }
-              >
-                <VexFlowSheet
-                  config={scaleRow.config}
-                  setConfig={(updater) => setRowConfig(scaleRow.id, updater)}
-                  endpoint="/api/scale"
-                  variant="original"
-                  scaleTitle={`Scale ${scaleRow.id}`}
-                  renderMode="print"
-                />
-              </ErrorBoundary>
-            </div>
-          ))}
-        </section>
-      )}
     </div>
   );
 }


### PR DESCRIPTION
Mobile Chrome's print engine only captures content in the visible layout flow. The previous approach added a 1024px-wide duplicate section that overflowed the mobile viewport horizontally; that overflow area was silently excluded from the print snapshot, producing a blank page.

New approach: re-render the existing visible scales at 1024px before calling window.print(), then restore them afterward.

- Worksheet: remove the separate print section entirely. Pass renderMode="print" to the main section's VexFlowSheets when printMode is true so they receive forcedWidth=1024 via VexFlowSheet's existing isPrintMode logic. Also set viewport to width=1024 inside the setTimeout (after VexFlow has re-rendered) so mobile browsers lay out at the print width before the dialog captures the page. Restore viewport and printMode after window.print() returns. Move no-print from the whole <section> back to the button container and the remove-button containers so the scales themselves are visible to the print engine.

- VexFlowRenderer: add a useEffect([forcedWidth]) that calls setContainerWidth(forcedWidth) whenever the prop is set. useState only runs its initializer once, so already-mounted renderers need this effect to adopt the new width when printMode toggles mid-session.