### PR TITLE
Wait one rAF after viewport change before calling window.print()

### DIFF
--- a/client/src/pages/Worksheet.jsx
+++ b/client/src/pages/Worksheet.jsx
@@ -47,13 +47,17 @@ export default function Worksheet() {
     setPrintMode(true);
 
     setTimeout(() => {
-      // Set viewport to 1024px so mobile browsers lay out at the print width
-      // before the print dialog captures the page.
+      // Set viewport to 1024px so mobile browsers lay out at the print width.
       viewportMeta.setAttribute("content", "width=1024");
-      window.print();
-      // Restore viewport and re-attach ResizeObserver for normal interaction.
-      viewportMeta.setAttribute("content", originalViewport);
-      setPrintMode(false);
+      // Wait one animation frame for the browser to reflow at the new viewport
+      // width before the print engine captures the page. Without this gap,
+      // mobile Chrome captures the layout at the old (device) viewport size.
+      requestAnimationFrame(() => {
+        window.print();
+        // Restore viewport and re-attach ResizeObserver for normal interaction.
+        viewportMeta.setAttribute("content", originalViewport);
+        setPrintMode(false);
+      });
     }, 500);
   }
 


### PR DESCRIPTION
The viewport meta was being set to width=1024 and window.print() called immediately after in the same synchronous block. Mobile Chrome had not yet reflowed the layout at the new width, so the print engine captured the page at the original device viewport size rather than 1024px.

Adding a requestAnimationFrame callback between the two operations gives the browser one layout cycle to settle at 1024px before the print dialog captures the DOM.