### PR TITLE
Remove redundant code across client and server

### DIFF
--- a/client/lib/render/vexflowRenderer.js
+++ b/client/lib/render/vexflowRenderer.js
@@ -44,7 +44,7 @@ export function renderScale({ context, scaleData, options }) {
       stave1.setContext(context).draw();
       if (containerWidth > 880) {
         stave1.setEndBarType(Barline.type.SINGLE);
-      } else if (containerWidth <= 880) {
+      } else {
         stave1.setEndBarType(Barline.type.DOUBLE);
       }
       stave1.draw();
@@ -68,7 +68,7 @@ export function renderScale({ context, scaleData, options }) {
             measureWidth,
           );
         }
-      } else if (containerWidth <= 880) {
+      } else {
         if (!firstMeasure?.notes?.length) {
           stave2 = new Stave(
             STAVE_SIDE_PADDING,

--- a/client/src/components/music/VexFlowRenderer.jsx
+++ b/client/src/components/music/VexFlowRenderer.jsx
@@ -67,7 +67,7 @@ export default function VexFlowRenderer({ scaleData, options, forcedWidth }) {
     // setting the width available for a measure
     if (containerWidth < 880) {
       availableMeasureWidth = containerWidth - STAVE_SIDE_PADDING * 2;
-    } else if (containerWidth >= 880) {
+    } else {
       if (directionMode === "both") {
         availableMeasureWidth = (containerWidth - STAVE_SIDE_PADDING * 2) / 2;
       } else if (

--- a/client/src/components/music/VexFlowSheet.jsx
+++ b/client/src/components/music/VexFlowSheet.jsx
@@ -61,8 +61,6 @@ export default function VexFlowSheet({
     measureSize,
   } = config;
 
-  const options = config;
-
   // audio controls state
   const { play, stop, audioError, playing } = useToneScaleAudio();
   const [tempo, setTempo] = useState(1);
@@ -75,8 +73,8 @@ export default function VexFlowSheet({
 
   // Fetch scale from server (with module-level cache to avoid redundant
   // network requests when the print section mounts with identical options).
-  const optionsRef = useRef(options);
-  optionsRef.current = options;
+  const optionsRef = useRef(config);
+  optionsRef.current = config;
 
   useEffect(() => {
     async function fetchScale() {
@@ -114,7 +112,7 @@ export default function VexFlowSheet({
     }
 
     fetchScale();
-  }, [options, endpoint]);
+  }, [config, endpoint]);
 
   // From minor, if a non-major tonic is picked from the dropdown, switch to C, vice versa for minor and A
   useEffect(() => {
@@ -287,7 +285,7 @@ export default function VexFlowSheet({
           ) : (
             <VexFlowRenderer
               scaleData={scaleData}
-              options={options}
+              options={config}
               forcedWidth={isPrintMode ? 1024 : undefined}
             />
           )}

--- a/client/src/components/ui/NavBar.jsx
+++ b/client/src/components/ui/NavBar.jsx
@@ -30,7 +30,7 @@ export default function NavBar() {
       setMobileWidth("100%");
       setMobileDisplay("block");
       setToggleMenu(true);
-    } else if (toggleMenu) {
+    } else {
       //console.log("Menu closed");
       setMobileWidth("0");
       setMobileDisplay("none");

--- a/server/services/theory/transposeEngine.js
+++ b/server/services/theory/transposeEngine.js
@@ -31,10 +31,7 @@ function parseTranspositionToken(token, tonic) {
 
   let octaveDirection = 0;
 
-  let uppercaseDiatonicOrder = [];
-  diatonicOrder.map((note) => {
-    uppercaseDiatonicOrder.push(note.toUpperCase());
-  });
+  const uppercaseDiatonicOrder = diatonicOrder.map((note) => note.toUpperCase());
 
   //console.log(`Diatonic order: ${uppercaseDiatonicOrder}`);
 
@@ -118,8 +115,6 @@ export function transposeTonic(tonic, keyInput, scale) {
   }
 
   const semitoneClassShift = (12 - transposedKeyIndex) % 12;
-  const octaveShiftSteps = octaveDirection;
-
   const newIndex = (index + semitoneClassShift + 12) % 12;
 
   keys = chromaticFlatKeys;
@@ -171,6 +166,6 @@ export function transposeTonic(tonic, keyInput, scale) {
 
   return {
     newTonic: keys[newIndex],
-    octaveTranspose: octaveShiftSteps,
+    octaveTranspose: octaveDirection,
   };
 }


### PR DESCRIPTION
- transposeEngine.js: replace side-effectful .map()+push anti-pattern with a direct .map() assignment; remove the octaveShiftSteps alias (was just a copy of octaveDirection)
- vexflowRenderer.js: simplify two `else if (containerWidth <= 880)` branches to plain `else` — the condition is always true when reached
- VexFlowRenderer.jsx: simplify `else if (containerWidth >= 880)` to `else` for the same reason
- NavBar.jsx: simplify `else if (toggleMenu)` to `else` in toggleNav — the condition is tautologically true in that branch
- VexFlowSheet.jsx: remove the `const options = config` alias and use `config` directly throughout (ref, effect dep array, renderer prop)

All 59 server theory tests continue to pass.